### PR TITLE
Improve About social icon accessibility

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -43,6 +43,32 @@
         <span>Folkstyle  </span>
         <span>Bloomingdale, IL</span>
       </div>
+      <div class="social-links">
+        <a
+          class="social-link"
+          href="https://www.facebook.com/profile.php?id=100083122968943"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Facebook"
+        >
+          <span class="sr-only">Facebook</span>
+          <svg aria-hidden="true" viewBox="0 0 24 24" width="20" height="20">
+            <path fill="currentColor" d="M22 12c0-5.52-4.48-10-10-10S2 6.48 2 12c0 4.99 3.66 9.12 8.44 9.88v-6.99H7.9v-2.89h2.54V9.79c0-2.5 1.49-3.89 3.77-3.89 1.09 0 2.23.2 2.23.2v2.45h-1.26c-1.24 0-1.63.77-1.63 1.56v1.87h2.78l-.44 2.89h-2.34v6.99C18.34 21.12 22 16.99 22 12z"/>
+          </svg>
+        </a>
+        <a
+          class="social-link"
+          href="https://www.instagram.com/teamel1tewrestling/"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Instagram"
+        >
+          <span class="sr-only">Instagram</span>
+          <svg aria-hidden="true" viewBox="0 0 24 24" width="20" height="20">
+            <path fill="currentColor" d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5zm0 2a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3H7zm5 3a5 5 0 1 1 0 10 5 5 0 0 1 0-10zm0 2a3 3 0 1 0 .001 6.001A3 3 0 0 0 12 9zm6.5-3a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/>
+          </svg>
+        </a>
+      </div>
     </section>
 
     <section id="register" class="section">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -33,6 +33,11 @@ a:hover{text-decoration:underline}
 .table th,.table td{border:1px solid rgba(255,255,255,0.15);padding:10px;text-align:left}
 .kit{display:flex;gap:8px;flex-wrap:wrap;margin-top:6px}
 .kit span{border:1px dashed rgba(255,255,255,0.4);padding:6px 10px;border-radius:8px}
+.social-links{display:flex;gap:12px;align-items:center;margin-top:16px}
+.social-link{display:inline-flex;align-items:center;justify-content:center;width:40px;height:40px;border-radius:50%;background:var(--elite-yellow);color:#000;transition:transform 0.2s ease,box-shadow 0.2s ease}
+.social-link:hover{transform:translateY(-2px);box-shadow:0 4px 12px rgba(0,0,0,0.35);text-decoration:none}
+.social-link:focus-visible{outline:2px solid var(--elite-white);outline-offset:2px;text-decoration:none}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 .notice{font-size:13px;color:#bdbdbd;margin-top:6px}
 @media (max-width:520px){
   .hero h2{font-size:32px}


### PR DESCRIPTION
## Summary
- add aria-labels and `rel="noopener noreferrer"` to the About section social links for safer external navigation
- close the Facebook SVG path and add a keyboard focus outline to the social buttons for better accessibility feedback

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68c9ac76f9b08333812c94f3298c0d8b