### PR TITLE
Add gear section with ordering form link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,6 +17,7 @@
     <nav>
       <a href="#about">About</a>&nbsp;&nbsp;
       <a href="#schedule">Schedule</a>&nbsp;&nbsp;
+      <a href="#gear">Gear</a>&nbsp;&nbsp;
       <a href="#coaches">Coaches</a>&nbsp;&nbsp;
       <a href="#register" class="btn primary">Register</a>
     </nav>
@@ -82,6 +83,26 @@
         <a class="btn ghost" target="_blank" rel="noopener" href="mailto:your-zelle-email@example.com?subject=TEAM%20EL1TE%20Dues&body=Please%20send%20Zelle%20payment%20to%20this%20address.">Pay with Zelle $?</a>
       </div>
       <p class="notice"> </p>
+    </section>
+
+    <section id="gear" class="section">
+      <h3>Gear</h3>
+      <p>Rep the squad on and off the mat. Use the form below to order shorts, T-shirts, sweatshirts, sweatpants, and singlets.</p>
+      <ul class="feature-list">
+        <li>High-quality materials ready for hard rounds and travel days.</li>
+        <li>Youth and adult sizes available for most items.</li>
+        <li>Bulk orders coordinated through TEAM EL1TE staff.</li>
+      </ul>
+      <div class="cta">
+        <!-- Replace with your real gear-order Google Form URL -->
+        <a
+          class="btn primary"
+          target="_blank"
+          rel="noopener"
+          href="https://docs.google.com/forms/d/e/1FAIpQLSfRreG1k8Q4QlwZsxXj8PHVy6c8N-gearForm/viewform?usp=pp_url"
+        >Order Gear</a>
+      </div>
+      <p class="notice">Questions about sizing or availability? Add them to your form submission and a coach will follow up.</p>
     </section>
 
     <section id="schedule" class="section">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -39,6 +39,8 @@ a:hover{text-decoration:underline}
 .social-link:focus-visible{outline:2px solid var(--elite-white);outline-offset:2px;text-decoration:none}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 .notice{font-size:13px;color:#bdbdbd;margin-top:6px}
+.feature-list{margin:16px 0;padding-left:20px;line-height:1.6;color:#e0e0e0}
+.feature-list li{margin-bottom:6px}
 @media (max-width:520px){
   .hero h2{font-size:32px}
   .brand h1{display:none}


### PR DESCRIPTION
## Summary
- add a Gear navigation link and section with ordering details
- include button that points to the gear Google Form for purchasing club apparel
- add supporting list styling for the new gear section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb09e65fb08333bbe34b1f017100ad