### PR TITLE
Add SportsYou social link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -165,7 +165,17 @@
             <path fill="currentColor" d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5zm0 2a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3H7zm5 3a5 5 0 1 1 0 10 5 5 0 0 1 0-10zm0 2a3 3 0 1 0 .001 6.001A3 3 0 0 0 12 9zm6.5-3a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/>
           </svg>
         </a>
-      </div> 
+        <a
+          class="social-link"
+          href="https://www.sportsyou.com/teams/te-31efcfb1-1836-419a-913b-b66c66a19384"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="SportsYou"
+        >
+          <span class="sr-only">SportsYou</span>
+          <span class="icon-text" aria-hidden="true">SY</span>
+        </a>
+      </div>
       <h3></h3>
       <div class="grid">
         <article class="card">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -51,6 +51,7 @@ a:hover{text-decoration:underline}
 .kit span{border:1px dashed rgba(255,255,255,0.4);padding:6px 10px;border-radius:8px}
 .social-links{display:flex;gap:12px;align-items:center;margin-top:16px}
 .social-link{display:inline-flex;align-items:center;justify-content:center;width:40px;height:40px;border-radius:50%;background:var(--elite-yellow);color:#000;transition:transform 0.2s ease,box-shadow 0.2s ease}
+.social-link .icon-text{font-weight:700;font-size:14px;letter-spacing:0.5px;text-transform:uppercase}
 .social-link:hover{transform:translateY(-2px);box-shadow:0 4px 12px rgba(0,0,0,0.35);text-decoration:none}
 .social-link:focus-visible{outline:2px solid var(--elite-white);outline-offset:2px;text-decoration:none}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}


### PR DESCRIPTION
## Summary
- add a SportsYou social media link next to the existing Facebook and Instagram icons
- style the SportsYou badge with centered "SY" initials to match the circular social buttons

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68cdc4f30b048333943e257f1922ffb5