### PR TITLE
Restore registration button and registration form content

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -25,6 +25,7 @@
       <a href="#about">About</a>
       <a href="#register">Register</a>
     </nav>
+    <a href="#register" class="btn primary register-link">Register</a>
   </header>
 
   <section class="hero">
@@ -32,7 +33,8 @@
       <h2>TEAM EL1TE Wrestling</h2>
       <p>Hard work, discipline, and teammates who push you to be your best. Join TEAM EL1TE Wrestling.</p>
       <div class="cta">
-        <!-- Registration is closed -->
+        <!-- TODO: Replace the # links below -->
+        <a class="btn primary" href="#register" id="register-now">Register Now</a> 
       </div>
       <p class="notice"></p>
     </div>
@@ -112,22 +114,31 @@
 
     <section id="register" class="section">
       <h3>Register</h3>
-      <p>Registration is closed for the season.</p>
-      <p class="notice">Existing members can continue paying monthly via Zelle, Venmo, or check.</p>
-      <a
-        id="venmo-link"
-        class="btn primary"
-        target="_blank"
-        rel="noopener"
-        data-app-url="venmo://paycharge?txn=pay&audience=private&recipients=TEAMEL1TE"
-        href="https://account.venmo.com/u/TEAMEL1TE"
-      >Pay with Venmo</a>
-      <p class="notice">Zelle: <a href="mailto:teamel1tewrestling@gmail.com">teamel1tewrestling@gmail.com</a></p>
-      <p class="notice">*When paying, please include wrestler name and month</p>
-      <p class="notice">JR $75/month</p>
-      <p class="notice">JV $125/month</p>
-      <p class="notice">Varsity $150/month</p>
-      <p class="notice">High School $100/month</p>
+      <p>Complete the Registration Form, then send payment. Your spot is confirmed when both steps are complete.</p>
+      <div class="cta">
+        <!-- Replace with your real Google Form URL -->
+        <a class="btn primary" target="_blank" rel="noopener" href="https://docs.google.com/forms/d/e/1FAIpQLSdlrf7u-DyrJAQNvoe2if5KPTWxaRUtnbgWjqqYMMuGRMoH8A/viewform?usp=header">Registration Form</a>
+        <!-- Replace with your real Venmo/Zelle links --> 
+        <a
+          id="venmo-link"
+          class="btn ghost"
+          target="_blank"
+          rel="noopener"
+          href="https://account.venmo.com/u/usf1ten"
+          data-app-url="venmo://u/usf1ten"
+        >
+          Pay with Venmo
+        </a>  
+      </div>
+      <p class="notice"> </p>
+      <p class="notice"> monthly payments can be made via
+zelle, venmo or check </p>
+      <p class="notice">  
+*When paying, please include wrestler name and month</p>
+      <p class="notice"> Jr $75/month</p>
+      <p class="notice"> Jv $125/month</p>
+      <p class="notice"> Varsity $150/month</p>
+      <p class="notice"> High School $100/month</p>
     </section>
 
 


### PR DESCRIPTION
### Motivation
- Re-enable the registration CTAs and form that were removed (reverting the removal introduced in PR #16) so visitors can find and use the registration flow.  
- Surface a clear `Register` entry point in both the header and hero so users can jump to the sign-up workflow.  
- Restore payment instructions and Venmo/Zelle details for members who need to pay monthly.

### Description
- Updated `docs/index.html` to re-add the standalone header `Register` button (`.register-link`).  
- Restored the hero CTA `Register Now` button that anchors to the `#register` section.  
- Reverted the `#register` section content to include the registration Google Form CTA, Venmo button/link, and monthly payment notes.  
- Committed the changes to the `docs/index.html` file.

### Testing
- Ran `git diff -- docs/index.html` to verify the intended file changes, which succeeded.  
- Launched a local static server with `python3 -m http.server 4173 --directory docs`, which served the updated site successfully.  
- Captured a full-page screenshot using the Playwright helper `mcp__browser_tools__run_playwright_script` to validate the restored CTAs, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69971b3b51888333b011fb1e04a4811e)