### PR TITLE
Update registration pricing to latest rates

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -118,10 +118,11 @@
 zelle, venmo or check </p>
       <p class="notice">  
 *When paying, please include wrestler name and month</p>
-      <p class="notice"> Jr $75/month</p>
-      <p class="notice"> Jv $125/month</p>
-      <p class="notice"> Varsity $150/month</p>
-      <p class="notice"> High School $100/month</p>
+      <p class="notice"><strong>Pricing (includes functional Friday workouts for age 10+)</strong></p>
+      <p class="notice">JR EL1TE or EL1TE 2 (1 day/week): <strong>$65/month</strong></p>
+      <p class="notice">EL1TE 2 (2 days/week): <strong>$100/month</strong></p>
+      <p class="notice">EL1TE: <strong>$125/month</strong></p>
+      <p class="notice">Drop in: <strong>$20</strong></p>
     </section>
 
 


### PR DESCRIPTION
### Motivation
- Update the site to reflect the new monthly and drop-in pricing in the registration section.
- Clarify that functional Friday workouts (age 10+) are included in the pricing copy.

### Description
- Replaced the old Jr/Jv/Varsity/High School pricing block in `docs/index.html` with a new pricing block containing `JR EL1TE or EL1TE 2 (1 day/week): $65/month`, `EL1TE 2 (2 days/week): $100/month`, `EL1TE: $125/month`, and `Drop in: $20`.
- Added a short pricing heading note that functional Friday workouts for age 10+ are included.
- This is a content-only change confined to the registration section and does not modify JS or CSS behavior.

### Testing
- Executed the automated replacement with a Python script that swapped the old HTML block for the new copy, and the script completed successfully.
- Verified the change via `git diff -- docs/index.html | sed -n '1,120p'` which shows the new content present and old values removed.
- Inspected the updated lines with `nl -ba docs/index.html | sed -n '108,132p'` and confirmed the new pricing block is correctly rendered in the file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc3ba7f1cc83338d90a94d7da51ca9)